### PR TITLE
Hold-tap adjustments to make switching instant

### DIFF
--- a/config/cradio.keymap
+++ b/config/cradio.keymap
@@ -34,7 +34,7 @@
             label = "hold_tap";
             compatible = "zmk,behavior-hold-tap";
             #binding-cells = <2>;
-            flavor = "hold-preferred";
+            flavor = "balanced";
             tapping-term-ms = <220>;
             quick-tap-ms = <150>;
             global-quick-tap;

--- a/config/cradio.keymap
+++ b/config/cradio.keymap
@@ -34,7 +34,7 @@
             label = "hold_tap";
             compatible = "zmk,behavior-hold-tap";
             #binding-cells = <2>;
-            flavor = "tap-preferred";
+            flavor = "hold-preferred";
             tapping-term-ms = <220>;
             quick-tap-ms = <150>;
             global-quick-tap;


### PR DESCRIPTION
Changed the "ht" behavior from tap-preferred to hold-preferred. This should make the switching (app and tab/model) instantaneous when typing slow. The "global-quick-tap" should prevent the hold behavior when I'm typing quickly.